### PR TITLE
Fix Contact link so that it scrolls down to proper section on page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 styles/.sass-cache/
+.DS_Store

--- a/about.html
+++ b/about.html
@@ -207,8 +207,8 @@
       </div>
     </section>
 
-    <section id="contact" class="contact">
-      <div class="border">
+    <section class="contact">
+      <div id="contact" class="border">
         <div class="line"></div>
         <div class="box-container">
           <div class="box-center">

--- a/ave.html
+++ b/ave.html
@@ -599,8 +599,8 @@
       </div>
     </section>
 
-    <section id="contact" class="contact">
-      <div class="border">
+    <section class="contact">
+      <div id="contact" class="border">
         <div class="line"></div>
         <div class="box-container">
           <div class="box-center">

--- a/index.html
+++ b/index.html
@@ -81,9 +81,8 @@
       </div>
     </section>
 
-    <section class="recent-work">
-
-      <div id="work" class="border">
+    <section id="work" class="recent-work">
+      <div class="border">
         <div class="line"></div>
         <div class="box-container">
           <div class="box-center">
@@ -131,7 +130,7 @@
       </div>
     </section>
 
-    <section class="other-works">
+    <section id="other-works" class="other-works">
       <div class="border">
         <div class="line"></div>
         <div class="box-container">
@@ -200,8 +199,8 @@
       </div>
     </section>
 
-    <section id="contact" class="contact">
-      <div class="border">
+    <section class="contact">
+      <div id="contact" class="border">
         <div class="line"></div>
         <div class="box-container">
           <div class="box-center">

--- a/managed-package.html
+++ b/managed-package.html
@@ -456,8 +456,8 @@
       </div>
     </section>
 
-    <section id="contact" class="contact">
-      <div class="border">
+    <section class="contact">
+      <div id="contact" class="border">
         <div class="line"></div>
         <div class="box-container">
           <div class="box-center">

--- a/nico.html
+++ b/nico.html
@@ -517,8 +517,8 @@
       </div>
     </section>
 
-    <section id="contact" class="contact">
-      <div class="border">
+    <section class="contact">
+      <div id="contact" class="border">
         <div class="line"></div>
         <div class="box-container">
           <div class="box-center">


### PR DESCRIPTION
For some reason, using `section id="contact"` was having it scroll to the section right above the Contact section. Adding the ID to the `div` class exhibits the proper behavior, so that's the workaround implemented here.
